### PR TITLE
Fix namespace for ColourTest class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",
-        "vimeo/psalm": "~3.7.0",
+        "vimeo/psalm": "^3.7",
         "innmind/black-box": "^4.0"
     },
     "conflict": {

--- a/tests/ColourTest.php
+++ b/tests/ColourTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Tests\Innmind\Colour\Colour;
+namespace Tests\Innmind\Colour;
 
 use Innmind\Colour\{
     Colour,

--- a/tests/Fixtures/ColourTest.php
+++ b/tests/Fixtures/ColourTest.php
@@ -6,10 +6,10 @@ namespace Tests\Innmind\Colour\Fixtures;
 use Fixtures\Innmind\Colour\Colour;
 use Innmind\Colour\RGBA;
 use Innmind\BlackBox\Set;
-use Innmind\BlackBox\Random;
+use Innmind\BlackBox\Random\RandomInt;
 use PHPUnit\Framework\TestCase;
 
-class ColourTest extends TestCase implements Random
+class ColourTest extends TestCase
 {
     public function testInterface()
     {
@@ -17,15 +17,10 @@ class ColourTest extends TestCase implements Random
 
         $this->assertInstanceOf(Set::class, $set);
 
-        foreach ($set->values(new self) as $value) {
+        foreach ($set->values(new RandomInt) as $value) {
             $this->assertInstanceOf(Set\Value::class, $value);
             $this->assertTrue($value->isImmutable());
             $this->assertInstanceOf(RGBA::class, $value->unwrap());
         }
-    }
-
-    public function __invoke(int $min, int $max): int
-    {
-        return random_int($min, $max);
     }
 }

--- a/tests/Fixtures/ColourTest.php
+++ b/tests/Fixtures/ColourTest.php
@@ -6,9 +6,10 @@ namespace Tests\Innmind\Colour\Fixtures;
 use Fixtures\Innmind\Colour\Colour;
 use Innmind\Colour\RGBA;
 use Innmind\BlackBox\Set;
+use Innmind\BlackBox\Random;
 use PHPUnit\Framework\TestCase;
 
-class ColourTest extends TestCase
+class ColourTest extends TestCase implements Random
 {
     public function testInterface()
     {
@@ -16,10 +17,15 @@ class ColourTest extends TestCase
 
         $this->assertInstanceOf(Set::class, $set);
 
-        foreach ($set->values() as $value) {
+        foreach ($set->values(new self) as $value) {
             $this->assertInstanceOf(Set\Value::class, $value);
             $this->assertTrue($value->isImmutable());
             $this->assertInstanceOf(RGBA::class, $value->unwrap());
         }
+    }
+
+    public function __invoke(int $min, int $max): int
+    {
+        return random_int($min, $max);
     }
 }


### PR DESCRIPTION
# Changed log

- Fox namespace to be `Tests\Innmind\Colour;`.
- The `Set::values` has the parameter with `Random` class and it should pass above parameter.
To fix above this issue, it should let `ColourTest` implement `Random` interface and pass the `ColourTest` class to the `Set::values` method.
- Add `pull_request` trigger action on GitHub Action.
- The `Psalm` on GitHub Action will be failed until this issue #2 has been resolved.