### PR TITLE
Drop PHP `8.4` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Requires PHP `8.5`
+
 ## 5.1.0 - 2026-05-14
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "http://github.com/Innmind/Colour/issues"
     },
     "require": {
-        "php": "~8.4",
+        "php": "~8.5",
         "innmind/immutable": "~6.0"
     },
     "autoload": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,5 @@
     </projectFiles>
     <issueHandlers>
         <InvalidOperand errorLevel="suppress" />
-        <UndefinedAttributeClass errorLevel="suppress" />
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
Since the latest version of `innmind/url` requires `8.5` essentially all packages for `innmind/foundation` can move to `8.5` as well.